### PR TITLE
Add common Python artifacts to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,26 @@
 !*.jpg
 !*.png
 !requirements*
+
+# Python artifacts
+__pycache__/
+*.py[cod]
+*.pyd
+*.pyo
+*.so
+*.egg
+*.egg-info/
+dist/
+build/
+
+# Virtual environments
+.env/
+venv/
+.venv/
+
+# Project-specific directories
+workspace/
+
+# IDE files
+.vscode/
+.idea/


### PR DESCRIPTION
## Summary
- ignore Python bytecode and build outputs
- ignore virtual environments and workspace directory

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b753273598832baf94a147b99c730b