### PR TITLE
fix: correct ProcessPriority enum values

### DIFF
--- a/xlib/os/os.py
+++ b/xlib/os/os.py
@@ -18,10 +18,10 @@ elif platform.system() == 'Darwin':
 _niceness = 0
 
 class ProcessPriority(IntEnum):
-    HIGH = 4,
-    ABOVE_NORMAL = 3,
-    NORMAL = 2,
-    BELOW_NORMAL = 1,
+    HIGH = 4
+    ABOVE_NORMAL = 3
+    NORMAL = 2
+    BELOW_NORMAL = 1
     IDLE = 0
 
 def get_process_priority() -> ProcessPriority:


### PR DESCRIPTION
## Summary
- ensure each ProcessPriority enum member stores an integer

## Testing
- `python - <<'PY'
from xlib.os.os import ProcessPriority
print(ProcessPriority.HIGH)
print([(p.name, p.value, type(p.value)) for p in ProcessPriority])
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b75336afdc832ba165db8df0614c78