### PR TITLE
Fix Linux process priority and add unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 !*.jpg
 !*.png
 !requirements*
+!tests/

--- a/tests/test_os_priority.py
+++ b/tests/test_os_priority.py
@@ -1,0 +1,42 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from xlib.os import os as xos
+from xlib.os.os import ProcessPriority
+
+class MockKernel32:
+    class PriorityClass:
+        HIGH_PRIORITY_CLASS = 1
+        ABOVE_NORMAL_PRIORITY_CLASS = 2
+        NORMAL_PRIORITY_CLASS = 3
+        BELOW_NORMAL_PRIORITY_CLASS = 4
+        IDLE_PRIORITY_CLASS = 5
+
+    def GetCurrentProcess(self):
+        return None
+
+    def GetPriorityClass(self, process):
+        return self.PriorityClass.HIGH_PRIORITY_CLASS
+
+def test_get_process_priority_linux(monkeypatch):
+    monkeypatch.setattr(xos, "is_win", False)
+    monkeypatch.setattr(xos, "is_darwin", False)
+    monkeypatch.setattr(xos, "is_linux", True)
+    monkeypatch.setattr(xos, "_niceness", -20)
+    assert xos.get_process_priority() is ProcessPriority.HIGH
+
+def test_get_process_priority_darwin(monkeypatch):
+    monkeypatch.setattr(xos, "is_win", False)
+    monkeypatch.setattr(xos, "is_linux", False)
+    monkeypatch.setattr(xos, "is_darwin", True)
+    monkeypatch.setattr(xos, "_niceness", -10)
+    assert xos.get_process_priority() is ProcessPriority.HIGH
+
+def test_get_process_priority_windows(monkeypatch):
+    monkeypatch.setattr(xos, "kernel32", MockKernel32(), raising=False)
+    monkeypatch.setattr(xos, "is_win", True)
+    monkeypatch.setattr(xos, "is_linux", False)
+    monkeypatch.setattr(xos, "is_darwin", False)
+    assert xos.get_process_priority() is ProcessPriority.HIGH

--- a/xlib/os/os.py
+++ b/xlib/os/os.py
@@ -45,6 +45,7 @@ def get_process_priority() -> ProcessPriority:
                 10  : ProcessPriority.BELOW_NORMAL,
                 20  : ProcessPriority.IDLE        ,
                 }[_niceness]
+        return prio
     elif is_darwin:
         prio = {-10 : ProcessPriority.HIGH        ,
                 -5  : ProcessPriority.ABOVE_NORMAL,


### PR DESCRIPTION
## Summary
- return Linux process priority value in `get_process_priority`
- add unit tests for Windows, Linux, and macOS priority handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b75351b97c832b9cb8d88fd9bcd71f